### PR TITLE
Create POC for switchboard based on autoscaling groups

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -21,6 +21,13 @@ export const handler = (event: any, context: any) =>
   );
 
 app.get("/", async (req, res) => {
+  res.render("index", {
+    title: "Stack Switchboard",
+    message: "Stack Switchboard"
+  });
+});
+
+app.get("/switchboard", async (req, res) => {
   let groups: EnrichedAutoScalingGroup[];
   try {
     groups = await fetchSwitchboardData();
@@ -29,7 +36,7 @@ app.get("/", async (req, res) => {
     groups = [];
   }
 
-  res.render("index", {
+  res.render("switchboard", {
     title: "Stack Switchboard",
     message: "Stack Switchboard",
     groups

--- a/app/app.ts
+++ b/app/app.ts
@@ -20,14 +20,14 @@ export const handler = (event: any, context: any) =>
   );
 
 app.get("/", async (req, res) => {
-  const stacks = await fetchSwitchboardData().catch(err => {
+  const groups = await fetchSwitchboardData().catch(err => {
     console.error("fetchSwitchboard data broke: ", err);
     throw new Error(err);
   });
   res.render("index", {
     title: "Stack Switchboard",
     message: "Stack Switchboard",
-    stacks
+    groups
   });
 });
 

--- a/app/app.ts
+++ b/app/app.ts
@@ -20,10 +20,13 @@ export const handler = (event: any, context: any) =>
   );
 
 app.get("/", async (req, res) => {
-  const groups = await fetchSwitchboardData().catch(err => {
-    console.error("fetchSwitchboard data broke: ", err);
-    throw new Error(err);
-  });
+  let groups: any[];
+  try {
+    groups = await fetchSwitchboardData();
+  } catch (err) {
+    console.error(err);
+    groups = [];
+  }
   res.render("index", {
     title: "Stack Switchboard",
     message: "Stack Switchboard",

--- a/app/app.ts
+++ b/app/app.ts
@@ -2,6 +2,7 @@ import express from "express";
 import awsServerlessExpress from "aws-serverless-express";
 import path from "path";
 import { fetchSwitchboardData } from "./utils/stackController";
+import { EnrichedAutoScalingGroup } from "./utils/interfaces";
 
 const app = express();
 
@@ -20,13 +21,14 @@ export const handler = (event: any, context: any) =>
   );
 
 app.get("/", async (req, res) => {
-  let groups: any[];
+  let groups: EnrichedAutoScalingGroup[];
   try {
     groups = await fetchSwitchboardData();
   } catch (err) {
     console.error(err);
     groups = [];
   }
+
   res.render("index", {
     title: "Stack Switchboard",
     message: "Stack Switchboard",

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -3,3 +3,13 @@ html, body {
     color: white;
     font-family: Arial, serif;
 }
+
+h1 {
+    padding: 10px;
+}
+
+.footer {
+    position: absolute;
+    bottom: 0;
+    height: 2.5rem;
+}

--- a/app/utils/interfaces.ts
+++ b/app/utils/interfaces.ts
@@ -4,7 +4,13 @@ export interface Stack {
   StackName: string;
 }
 
+export interface DesiredTags {
+  stack: string;
+  stage: string;
+  cloudformationName: string;
+}
+
 export interface EnrichedAutoScalingGroup {
   group: AutoScaling.AutoScalingGroup;
-  tags: { stack: string; stage: string };
+  tags: DesiredTags;
 }

--- a/app/utils/interfaces.ts
+++ b/app/utils/interfaces.ts
@@ -1,26 +1,10 @@
-import { CloudFormation } from "aws-sdk";
+import { AutoScaling } from "aws-sdk";
 
 export interface Stack {
   StackName: string;
 }
 
-export interface StackResources {
-  stack: {
-    StackName: string;
-    description: string;
-    driftStatus: string;
-  };
-  autoscaling: {
-    desired: number;
-    max: number;
-    min: number;
-  };
-  resources: CloudFormation.StackResourceSummary[];
-}
-
-export interface AutoScalingGroupInfo extends StackResources {
-  autoScalingGroupName: string;
-  MinSize: number;
-  DesiredCapacity: number;
-  MaxSize: number;
+export interface EnrichedAutoScalingGroup {
+  group: AutoScaling.AutoScalingGroup;
+  tags: { stack: string; stage: string };
 }

--- a/app/utils/stackController.ts
+++ b/app/utils/stackController.ts
@@ -1,168 +1,59 @@
-import AWS, { CloudFormation, AutoScaling } from "aws-sdk";
-import { ListStackResourcesOutput } from "aws-sdk/clients/cloudformation";
-import { AutoScalingGroupInfo, Stack, StackResources } from "./interfaces";
+import AWS, { AutoScaling } from "aws-sdk";
+import { Stack } from "./interfaces";
 
 const params = {
   region: "eu-west-1"
 };
 
-const cloudFormation = new AWS.CloudFormation(params);
-
-function byStackName(a: Stack, b: Stack): number {
-  const stackA: string = a.StackName.toLowerCase();
-  const stackB: string = b.StackName.toLowerCase();
-  if (stackA < stackB) {
+function byStackName(
+  a: AutoScaling.AutoScalingGroup,
+  b: AutoScaling.AutoScalingGroup
+): number {
+  const groupA: string = a.AutoScalingGroupName.toLowerCase();
+  const groupB: string = b.AutoScalingGroupName.toLowerCase();
+  if (groupA < groupB) {
     return -1;
-  } else if (stackA > stackB) {
+  } else if (groupA > groupB) {
     return 1;
   }
   return 0;
 }
 
-function desiredStacks(): (stack: Stack) => boolean {
-  return (stack: Stack) =>
-    (stack.StackName.includes("flexible") ||
-      stack.StackName.includes("Flexible")) &&
-    stack.StackName.includes("CODE");
+function desiredGroups(): (group: AutoScaling.AutoScalingGroup) => boolean {
+  return (group: AutoScaling.AutoScalingGroup) =>
+    (group.AutoScalingGroupName.includes("flexible") ||
+      group.AutoScalingGroupName.includes("Flexible")) &&
+    group.AutoScalingGroupName.includes("CODE");
 }
 
-const queryCloudFormation = async (
-  NextToken?: string
-): Promise<{ stacks: CloudFormation.StackSummaries; NextToken: string }> => {
-  return await cloudFormation
-    .listStacks({ NextToken })
+const getAutoScalingGroupState = async (): Promise<
+  AutoScaling.AutoScalingGroup[]
+> => {
+  const autoScaling = new AWS.AutoScaling(params);
+
+  return await autoScaling
+    .describeAutoScalingGroups({})
     .promise()
-    .then((data: CloudFormation.ListStacksOutput) => {
-      if (data.StackSummaries) {
-        return {
-          stacks: data.StackSummaries,
-          NextToken: data.NextToken
-        };
-      } else {
-        throw Error("StackSummaries missing");
-      }
-    })
+    .then(
+      (response: AutoScaling.AutoScalingGroupsType) =>
+        response.AutoScalingGroups
+    )
     .catch(err => {
-      console.error("CF QUERY ERROR: ", err);
+      console.error(err);
       return err;
     });
 };
 
-const getStackResources = async (stack: Stack): Promise<StackResources> => {
-  return await cloudFormation
-    .listStackResources({ StackName: stack.StackName })
-    .promise()
-    .then((resources: ListStackResourcesOutput) => {
-      if (resources.StackResourceSummaries) {
-        return {
-          stack,
-          resources: resources.StackResourceSummaries.filter(resource =>
-            resource.ResourceType.includes("AWS::AutoScaling::AutoScalingGroup")
-          )
-        };
-      } else {
-        return {
-          stack,
-          resources: []
-        };
-      }
-    })
-    .catch(err => err);
-};
-
-const getAutoScalingGroupState = async (
-  autoScalingGroupName: string
-): Promise<AutoScalingGroupInfo> => {
-  const autoScaling = new AWS.AutoScaling(params);
-
-  return await autoScaling
-    .describeAutoScalingGroups({
-      AutoScalingGroupNames: [autoScalingGroupName]
-    })
-    .promise()
-    .then((response: AutoScaling.AutoScalingGroupsType) => {
-      const {
-        MinSize,
-        DesiredCapacity,
-        MaxSize
-      } = response.AutoScalingGroups[0];
-      return { autoScalingGroupName, MinSize, DesiredCapacity, MaxSize };
-      //     return `${autoScalingGroupName}:
-      // Min: ${response.AutoScalingGroups[0].MinSize},
-      // Desired: ${response.AutoScalingGroups[0].DesiredCapacity},
-      // Max: ${response.AutoScalingGroups[0].MaxSize}`;
-    })
-    .catch(err => err);
-};
-
-async function fetchAllStacks(): Promise<Stack[]> {
-  let stacks: Stack[] = [];
-  let response: {
-    stacks: CloudFormation.StackSummaries;
-    NextToken: string;
-  } = await queryCloudFormation().catch(err => {
-    throw new Error(err);
-  });
-
-  stacks = stacks.concat(response.stacks);
-  while (response.NextToken) {
-    response = await queryCloudFormation(response.NextToken).then(res => res);
-    stacks = stacks.concat(response.stacks);
-  }
-
-  return stacks;
-}
-
 export const fetchSwitchboardData = async () => {
-  try {
-    const stacks: Stack[] | void = await fetchAllStacks().catch(err => {
+  const autoscalingGroups: AutoScaling.AutoScalingGroup[] = await getAutoScalingGroupState()
+    .then((groups: AutoScaling.AutoScalingGroup[]) =>
+      groups.filter(desiredGroups).sort(byStackName)
+    )
+    .catch(err => {
       throw new Error(err);
     });
-
-    const usefulStacks: Stack[] = stacks
-      .filter(desiredStacks())
-      .sort(byStackName);
-
-    let enrichedStacks: StackResources[] = [];
-    for (let stack of usefulStacks) {
-      let result: StackResources = await getStackResources(stack);
-      enrichedStacks.push(result);
-    }
-
-    let stacksWithASGInfo: any[] = [];
-    for (let stackWithResources of enrichedStacks) {
-      console.log(`\n******* ${stackWithResources.stack.StackName} ********`);
-      if (
-        stackWithResources.resources.length > 0 &&
-        stackWithResources.resources[0].PhysicalResourceId
-      ) {
-        console.log(`[${stackWithResources.resources.length}] resources found`);
-        let fullyBuiltStackWithASGInformation = Object.assign(
-          stackWithResources,
-          { autoScalingGroups: <AutoScalingGroupInfo[]>[] }
-        );
-
-        for (let resource of stackWithResources.resources) {
-          if (resource.PhysicalResourceId) {
-            const stateInfo: AutoScalingGroupInfo = await getAutoScalingGroupState(
-              resource.PhysicalResourceId
-            );
-            fullyBuiltStackWithASGInformation.autoScalingGroups.push(stateInfo);
-            console.log(stateInfo);
-
-            stacksWithASGInfo.push(fullyBuiltStackWithASGInformation);
-          }
-        }
-      } else {
-        console.log(
-          `${stackWithResources.stack.StackName} does not have an ASG`
-        );
-      }
-    }
-    return stacksWithASGInfo;
-  } catch (err) {
-    throw new Error(err);
-  }
+  console.log(autoscalingGroups.length);
+  return autoscalingGroups;
 };
 
 module.exports = { fetchSwitchboardData };

--- a/app/views/index.ejs
+++ b/app/views/index.ejs
@@ -14,15 +14,14 @@
 </head>
 
 <body>
-<div class="">
-<h1 style="text-align: center"><%= message %></h1>
+    <h1 style="text-align: center"><%= message %></h1>
 
     <table class="table table-responsive-lg table-dark table-striped table-hover">
         <thead>
             <tr>
-                <th scope="col">Stack</th>
-                <th scope="col">ASG Name</th>
+                <th scope="col">CloudFormation Stack</th>
                 <th scope="col">Stage</th>
+                <th scope="col">ASG Name</th>
                 <th scope="col" class="th-md">Minimum Size</th>
                 <th scope="col" class="th-md">Desired Size</th>
                 <th scope="col" class="th-md">Maximum Size</th>
@@ -34,19 +33,18 @@
         <tbody>
         <% for (const group of groups) { %>
             <tr>
-                <td style="; font-weight: bold; font-size: 120%"><%= group.tags.stack %></td>
-                <td style="font-weight: bold; font-size: 120%"><%= group.group.AutoScalingGroupName %></td>
-                <td style=""><%= group.tags.stage %></td>
-                <td style=""><%= group.group.MinSize %></td>
-                <td style=""><%= group.group.DesiredCapacity %></td>
-                <td style=""><%= group.group.MaxSize %></td>
-                <td style="">
-                    <% if (group.group.DesiredCapacity === group.group.MinSize) { %>
-                        <div style="color: lightgreen">Desired: <%= group.group.DesiredCapacity %></div>
-                    <% } else { %>
-                        <div style="color: palevioletred">Desired: <%= group.group.DesiredCapacity %></div>
-                    <% } %>
-                    <br/>
+                <td ><%= group.tags.cloudformationName %></td>
+                <td ><%= group.tags.stage %></td>
+                <td><%= group.group.AutoScalingGroupName %></td>
+                <td ><%= group.group.MinSize %></td>
+                <td ><%= group.group.DesiredCapacity %></td>
+                <td ><%= group.group.MaxSize %></td>
+                <td >
+            <% if (group.group.DesiredCapacity === group.group.MinSize) { %>
+                    <span style="color: lightgreen">Desired: <%= group.group.DesiredCapacity %></span>
+            <% } else { %>
+                    <span style="color: palevioletred">Desired: <%= group.group.DesiredCapacity %></span>
+            <% } %>
                 </td>
                 <td style="min-width: 5%"><button class="btn btn-warning" onclick="event.target.innerHTML = 'Scaling down...'">Scale down</button></td>
             </tr>
@@ -54,7 +52,6 @@
         </tbody>
     </table>
 
-</div>
 </body>
 
 </html>

--- a/app/views/index.ejs
+++ b/app/views/index.ejs
@@ -1,57 +1,17 @@
-<!DOCTYPE html>
-<html lang="en">
-
-<head>
-    <meta charset="utf-8">
-    <title><%= title %></title>
-    <meta name="author" content="">
-    <meta name="description" content="">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
-    <link href="css/styles.css" rel="stylesheet">
-
-</head>
+<%- include partials/header.ejs %>
 
 <body>
+    <%- include nav.ejs %>
+
     <h1 style="text-align: center"><%= message %></h1>
+    <div class="container">
+        <h2>Instructions</h2>
+        <div>
+            TBC
+        </div>
+    </div>
 
-    <table class="table table-responsive-lg table-dark table-striped table-hover">
-        <thead>
-            <tr>
-                <th scope="col">CloudFormation Stack</th>
-                <th scope="col">Stage</th>
-                <th scope="col">ASG Name</th>
-                <th scope="col" class="th-md">Minimum Size</th>
-                <th scope="col" class="th-md">Desired Size</th>
-                <th scope="col" class="th-md">Maximum Size</th>
-                <th scope="col" class="th-md">Alive</th>
-                <th scope="col">Switch</th>
-            </tr>
-        </thead>
-
-        <tbody>
-        <% for (const group of groups) { %>
-            <tr>
-                <td ><%= group.tags.cloudformationName %></td>
-                <td ><%= group.tags.stage %></td>
-                <td><%= group.group.AutoScalingGroupName %></td>
-                <td ><%= group.group.MinSize %></td>
-                <td ><%= group.group.DesiredCapacity %></td>
-                <td ><%= group.group.MaxSize %></td>
-                <td >
-            <% if (group.group.DesiredCapacity === group.group.MinSize) { %>
-                    <span style="color: lightgreen">Desired: <%= group.group.DesiredCapacity %></span>
-            <% } else { %>
-                    <span style="color: palevioletred">Desired: <%= group.group.DesiredCapacity %></span>
-            <% } %>
-                </td>
-                <td style="min-width: 5%"><button class="btn btn-warning" onclick="event.target.innerHTML = 'Scaling down...'">Scale down</button></td>
-            </tr>
-        <% } %>
-        </tbody>
-    </table>
-
+    <%- include partials/footer.ejs %>
 </body>
 
 </html>

--- a/app/views/index.ejs
+++ b/app/views/index.ejs
@@ -20,30 +20,32 @@
     <table class="table table-responsive-lg table-dark table-striped table-hover">
         <thead>
         <tr>
-            <th scope="col">Stack Name</th>
-            <th scope="col">Description</th>
-            <th scope="col">Drift Status</th>
+            <th scope="col">ASG Name</th>
+            <th scope="col">ARN</th>
+            <th scope="col">Tags</th>
             <th scope="col">Switch</th>
             <th scope="col" class="th-md">ASG Desired Amount</th>
         </tr>
         </thead>
 
         <tbody>
-    <% for (const stack of stacks) { %>
+    <% for (const group of groups) { %>
             <tr>
-                <td><%= stack.stack.StackName %></td>
-                <td><%= stack.stack.TemplateDescription %></td>
-                <td><%= stack.stack.DriftInformation.StackDriftStatus %></td>
-                <td><button class="btn btn-warning" onclick="console.log('Dope!')">Scale down</button></td>
+                <td style="min-width: 20%; font-weight: bold; font-size: 120%"><%= group.AutoScalingGroupName %></td>
+                <td style=""><%= group.AutoScalingGroupARN %></td>
+                <td style="width: 10%"><%= JSON.stringify(group.Tags) %></td>
+                <td style="min-width: 5%"><button class="btn btn-warning" onclick="console.log('Dope!')">Scale down</button></td>
                 <td>
-                    <% for (const asg of stack.autoScalingGroups) { %>
+                    <div></div>
+                    <div>MinSize: <%= group.MinSize %></div>
+                    <% if (group.DesiredCapacity === group.MinSize) { %>
+                        <div style="color: lightgreen">Desired: <%= group.DesiredCapacity %></div>
+                    <% } else { %>
+                        <div style="color: palevioletred">Desired: <%= group.DesiredCapacity %></div>
 
-                        <div><%= asg.autoScalingGroupName %></div>
-                        <div>MinSize: <%= asg.MinSize %></div>
-                        <div>Desired: <%= asg.DesiredCapacity %></div>
-                        <div>MaxSize: <%= asg.MaxSize %></div>
-                        <br/>
                     <% } %>
+                    <div>MaxSize: <%= group.MaxSize %></div>
+                <br/>
 
                 </td>
             </tr>

--- a/app/views/index.ejs
+++ b/app/views/index.ejs
@@ -19,37 +19,38 @@
 
     <table class="table table-responsive-lg table-dark table-striped table-hover">
         <thead>
-        <tr>
-            <th scope="col">ASG Name</th>
-            <th scope="col">ARN</th>
-            <th scope="col">Tags</th>
-            <th scope="col">Switch</th>
-            <th scope="col" class="th-md">ASG Desired Amount</th>
-        </tr>
+            <tr>
+                <th scope="col">Stack</th>
+                <th scope="col">ASG Name</th>
+                <th scope="col">Stage</th>
+                <th scope="col" class="th-md">Minimum Size</th>
+                <th scope="col" class="th-md">Desired Size</th>
+                <th scope="col" class="th-md">Maximum Size</th>
+                <th scope="col" class="th-md">Alive</th>
+                <th scope="col">Switch</th>
+            </tr>
         </thead>
 
         <tbody>
-    <% for (const group of groups) { %>
+        <% for (const group of groups) { %>
             <tr>
-                <td style="min-width: 20%; font-weight: bold; font-size: 120%"><%= group.AutoScalingGroupName %></td>
-                <td style=""><%= group.AutoScalingGroupARN %></td>
-                <td style="width: 10%"><%= JSON.stringify(group.Tags) %></td>
-                <td style="min-width: 5%"><button class="btn btn-warning" onclick="console.log('Dope!')">Scale down</button></td>
-                <td>
-                    <div></div>
-                    <div>MinSize: <%= group.MinSize %></div>
-                    <% if (group.DesiredCapacity === group.MinSize) { %>
-                        <div style="color: lightgreen">Desired: <%= group.DesiredCapacity %></div>
+                <td style="; font-weight: bold; font-size: 120%"><%= group.tags.stack %></td>
+                <td style="font-weight: bold; font-size: 120%"><%= group.group.AutoScalingGroupName %></td>
+                <td style=""><%= group.tags.stage %></td>
+                <td style=""><%= group.group.MinSize %></td>
+                <td style=""><%= group.group.DesiredCapacity %></td>
+                <td style=""><%= group.group.MaxSize %></td>
+                <td style="">
+                    <% if (group.group.DesiredCapacity === group.group.MinSize) { %>
+                        <div style="color: lightgreen">Desired: <%= group.group.DesiredCapacity %></div>
                     <% } else { %>
-                        <div style="color: palevioletred">Desired: <%= group.DesiredCapacity %></div>
-
+                        <div style="color: palevioletred">Desired: <%= group.group.DesiredCapacity %></div>
                     <% } %>
-                    <div>MaxSize: <%= group.MaxSize %></div>
-                <br/>
-
+                    <br/>
                 </td>
+                <td style="min-width: 5%"><button class="btn btn-warning" onclick="event.target.innerHTML = 'Scaling down...'">Scale down</button></td>
             </tr>
-    <% } %>
+        <% } %>
         </tbody>
     </table>
 

--- a/app/views/nav.ejs
+++ b/app/views/nav.ejs
@@ -1,0 +1,12 @@
+<nav class="navbar navbar-dark navbar-expand-lg bg-dark">
+    <a class="navbar-brand" href="#"><%= title %></a>
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
+        <div class="navbar-nav">
+            <a class="nav-item nav-link" href="/">Home <span class="sr-only">(current)</span></a>
+            <a class="nav-item nav-link" href="/switchboard">Switchboard</a>
+        </div>
+    </div>
+</nav>

--- a/app/views/partials/footer.ejs
+++ b/app/views/partials/footer.ejs
@@ -1,0 +1,5 @@
+<div class="container">
+    <footer class="footer">
+        Contact <a href="mailto:editorial.tools.dev@theguardian.com">Editorial Tools</a> for support
+    </footer>
+</div>

--- a/app/views/partials/header.ejs
+++ b/app/views/partials/header.ejs
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <title><%= title %></title>
+    <meta name="author" content="">
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+    <link href="css/styles.css" rel="stylesheet">
+
+</head>

--- a/app/views/switchboard.ejs
+++ b/app/views/switchboard.ejs
@@ -1,17 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
+<%- include partials/header.ejs %>
 
-<head>
-    <meta charset="utf-8">
-    <title><%= title %></title>
-    <meta name="author" content="">
-    <meta name="description" content="">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
-    <link href="css/styles.css" rel="stylesheet">
-
-</head>
 
 <body>
 <%- include nav.ejs %>

--- a/app/views/switchboard.ejs
+++ b/app/views/switchboard.ejs
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <title><%= title %></title>
+    <meta name="author" content="">
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+    <link href="css/styles.css" rel="stylesheet">
+
+</head>
+
+<body>
+<%- include nav.ejs %>
+<table class="table table-responsive-lg table-dark table-striped table-hover">
+    <thead>
+    <tr>
+        <th scope="col">CloudFormation Stack</th>
+        <th scope="col">Stage</th>
+        <th scope="col">ASG Name</th>
+        <th scope="col" class="th-md">Minimum Size</th>
+        <th scope="col" class="th-md">Desired Size</th>
+        <th scope="col" class="th-md">Maximum Size</th>
+        <th scope="col" class="th-md">Alive</th>
+        <th scope="col">Switch</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    <% for (const group of groups) { %>
+        <tr>
+            <td ><%= group.tags.cloudformationName %></td>
+            <td ><%= group.tags.stage %></td>
+            <td><%= group.group.AutoScalingGroupName %></td>
+            <td ><%= group.group.MinSize %></td>
+            <td ><%= group.group.DesiredCapacity %></td>
+            <td ><%= group.group.MaxSize %></td>
+            <td >
+                <% if (group.group.DesiredCapacity === group.group.MinSize) { %>
+                    <span style="color: lightgreen">Desired: <%= group.group.DesiredCapacity %></span>
+                <% } else { %>
+                    <span style="color: palevioletred">Desired: <%= group.group.DesiredCapacity %></span>
+                <% } %>
+            </td>
+            <td style="min-width: 5%"><button class="btn btn-warning" onclick="event.target.innerHTML = 'Scaling down...'">Scale down</button></td>
+        </tr>
+    <% } %>
+    </tbody>
+</table>
+
+<%- include partials/footer.ejs %>
+
+</body>
+
+</html>


### PR DESCRIPTION
This PR exposes two endpoints: 

### * *`/`*

This will render the landing page, which will eventually have documentation on how to use the switchboard. This will be of particular use to Central Prod, who have expressed interest in having detailed explanations as to how to interact with the board.


### * *`/switchboard`*

This is where the switchboard lives. This has a table of all ASGs, with their requisite stack name and state. The backend implementation of scaling down ASGs have not yet been implemented.